### PR TITLE
pull feature-patch-wordproc to master

### DIFF
--- a/wordprocessor/wordprocessor.py
+++ b/wordprocessor/wordprocessor.py
@@ -336,7 +336,7 @@ class MainWindow(QMainWindow):
             self.dialog_critical(str(e))
 
     def file_saveas(self):
-        path, _ = QFileDialog.getSaveFileName(self, "Save file", "", "HTML documents (*.html);Text documents (*.txt);All files (*.*)")
+        path, _ = QFileDialog.getSaveFileName(self, "Save file", "", "HTML documents ( *.html ); Text documents ( *.txt ); All files ( *.* )")
 
         if not path:
             # If dialog is cancelled, will return ''

--- a/wordprocessor/wordprocessor.py
+++ b/wordprocessor/wordprocessor.py
@@ -182,7 +182,7 @@ class MainWindow(QMainWindow):
 
         # We need references to these actions/settings to update as selection changes, so attach to self.
         self.fonts = QFontComboBox()
-        self.fonts.currentFontChanged.connect(self.editor.setCurrentFont)
+        self.fonts.currentFontChanged.connect(self.switch_font)
         format_toolbar.addWidget(self.fonts)
 
         self.fontsize = QComboBox()
@@ -270,7 +270,10 @@ class MainWindow(QMainWindow):
         self.update_format()
         self.update_title()
         self.show()
-
+    
+    def switch_font(self, new_font):
+        self.editor.setFontFamily(QFont.family(new_font))
+    
     def block_signals(self, objects, b):
         for o in objects:
             o.blockSignals(b)


### PR DESCRIPTION
This feature patches two bugs in the word processor.
- previously, the default save format did not support formatting. The default has been changed.
- previously, not all the fonts in the font selection menu were actually available, this has been fixed.